### PR TITLE
More strict sanitisation of the file name

### DIFF
--- a/digestparser/output.py
+++ b/digestparser/output.py
@@ -57,7 +57,7 @@ def docx_file_name(digest, digest_config=None):
         author=digest.author,
         msid=str(utils.msid_from_doi(digest.doi))
     )
-    return file_name
+    return utils.sanitise_file_name(file_name)
 
 
 def digest_docx(digest, output_file_name, output_dir):

--- a/digestparser/utils.py
+++ b/digestparser/utils.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 "utility helper functions"
 import re
 import urllib
@@ -11,6 +13,28 @@ def sanitise(file_name):
     file_name = file_name.replace('\\', '')
     file_name = re.sub(r'\.+', '.', file_name)
     file_name = file_name.lstrip('.')
+    return file_name
+
+
+def char_map():
+    "set of character replacements for use in sanitising file names"
+    return {
+        u'’': "'",
+        u'‘': "'",
+        u'“': '"',
+        u'”': '"',
+    }
+
+
+def sanitise_file_name(file_name):
+    "more extensive sanitising of a file name with some replacement characters and allowed ones"
+    # basic sanitise first
+    file_name = sanitise(file_name)
+    # character replacements
+    for match, replacement in char_map().items():
+        file_name = re.sub(match, replacement, file_name)
+    # remove more unsafe impossible file name characters
+    file_name = re.sub(r'[*:"<>|]', '', file_name)
     return file_name
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -90,7 +90,14 @@ class TestOutput(unittest.TestCase):
             'use_config': False,
             'expected_file_name': u'Nö_99999.docx'
         },
-        )
+        {
+            'scenario': 'ugly ugly author name and not using a config',
+            'author': u'‘“Nö(%)”/\\:"<>|*’',
+            'doi': '10.7554/eLife.99999',
+            'use_config': False,
+            'expected_file_name': u"'Nö(%)'_99999.docx"
+        },
+    )
     def test_docx_file_name(self, test_data):
         "docx output file name tests for various input"
         # build the Digest object
@@ -109,6 +116,15 @@ class TestOutput(unittest.TestCase):
             u"failed in scenario '{scenario}', got file_name {file_name}".format(
                 scenario=test_data.get('scenario'),
                 file_name=file_name
+                ))
+        # test for creating the file on disk
+        output_file_name = output.digest_docx(digest, file_name, 'tmp')
+        self.assertEqual(
+            os.path.join('tmp', test_data.get('expected_file_name')),
+            output_file_name,
+            u"failed creating file in scenario '{scenario}', got file_name {file_name}".format(
+                scenario=test_data.get('scenario'),
+                file_name=output_file_name
                 ))
 
 


### PR DESCRIPTION
Fixes https://github.com/elifesciences/digest-parser/issues/33

More strict sanitisation of the file name when created by replacing and stripping out unwanted characters.

Test are passing and I want to try it out today, so I will merge the moment PR tests pass.