### PR TITLE
Character decoding tweaks for the output file name

### DIFF
--- a/digestparser/output.py
+++ b/digestparser/output.py
@@ -54,7 +54,7 @@ def docx_file_name(digest, digest_config=None):
         file_name_pattern = digest_config.get('output_file_name_pattern')
     # collect the values from the digest if present
     file_name = file_name_pattern.format(
-        author=digest.author,
+        author=utils.unicode_decode(digest.author),
         msid=str(utils.msid_from_doi(digest.doi))
     )
     return utils.sanitise_file_name(file_name)

--- a/digestparser/utils.py
+++ b/digestparser/utils.py
@@ -5,6 +5,15 @@ import re
 import urllib
 
 
+def unicode_decode(string):
+    "try to decode from utf8"
+    try:
+        string = string.decode('utf8')
+    except (UnicodeEncodeError, AttributeError):
+        pass
+    return string
+
+
 def sanitise(file_name):
     "replace unwanted characters in file name if present"
     if not file_name:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -73,11 +73,11 @@ class TestOutput(unittest.TestCase):
             'author': None,
             'doi': None,
             'use_config': False,
-            'expected_file_name': 'None_0None.docx'
+            'expected_file_name': u'None_0None.docx'
         },
         {
             'scenario': 'unicode author name using a default config',
-            'author': u'Nö',
+            'author': 'Nö',
             'doi': '10.7554/eLife.99999',
             'use_config': True,
             'config_section': None,
@@ -92,10 +92,17 @@ class TestOutput(unittest.TestCase):
         },
         {
             'scenario': 'ugly ugly author name and not using a config',
-            'author': u'‘“Nö(%)”/\\:"<>|*’',
+            'author': '‘“Nö(%)”/\\:"<>|*’',
             'doi': '10.7554/eLife.99999',
             'use_config': False,
             'expected_file_name': u"'Nö(%)'_99999.docx"
+        },
+        {
+            'scenario': 'testing additional unicode characters',
+            'author': 'á好',
+            'doi': '10.7554/eLife.99999',
+            'use_config': False,
+            'expected_file_name': u'á好_99999.docx'
         },
     )
     def test_docx_file_name(self, test_data):


### PR DESCRIPTION
When forming the output file name, try decoding from utf8, but if not it is also ok.

Some characters that should be allowed in file names don't seem to be working when using the author name. This more flexible decoding may work, and will try it in the bot activity on real docx input.