### PR TITLE
Save docx to a file name instead of a file handle

### DIFF
--- a/digestparser/output.py
+++ b/digestparser/output.py
@@ -83,8 +83,7 @@ def digest_docx(digest, output_file_name, output_dir):
                 font.superscript = True
     # save the file
     output_file = os.path.join(output_dir, output_file_name)
-    with open(output_file, 'wb') as open_file:
-        document.save(open_file)
+    document.save(output_file)
     return output_file
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -104,6 +104,13 @@ class TestOutput(unittest.TestCase):
             'use_config': False,
             'expected_file_name': u'á好_99999.docx'
         },
+        {
+            'scenario': 'testing unicode characters using the config pattern',
+            'author': u'\xe1',
+            'doi': '10.7554/eLife.99999',
+            'use_config': True,
+            'expected_file_name': u'á_99999.docx'
+        },
     )
     def test_docx_file_name(self, test_data):
         "docx output file name tests for various input"


### PR DESCRIPTION
Test using the .cfg file pattern and use document.save() with a filename instead of a file handle.

Trying to fix the bug the bot is experiencing, this may help and not hurt.