### PR TITLE
Convert the file name pattern to unicode when taken from the cfg file.

### DIFF
--- a/digestparser/output.py
+++ b/digestparser/output.py
@@ -1,9 +1,9 @@
 "build DOCX output from digest content"
 
 import os
-from io import open
 from bs4 import BeautifulSoup
 from docx import Document
+from elifetools.utils import unicode_value
 from digestparser.build import build_digest
 import digestparser.utils as utils
 
@@ -52,7 +52,7 @@ def docx_file_name(digest, digest_config=None):
     default_file_name_pattern = u'{author}_{msid:0>5}.docx'
     file_name_pattern = default_file_name_pattern
     if digest_config and 'output_file_name_pattern' in digest_config:
-        file_name_pattern = digest_config.get('output_file_name_pattern')
+        file_name_pattern = unicode_value(digest_config.get('output_file_name_pattern'))
     # collect the values from the digest if present
     file_name = file_name_pattern.format(
         author=utils.unicode_decode(digest.author),


### PR DESCRIPTION
Finally figured out a way to recreate the bug on the bot instance, it looks to be related to the ``.cfg`` value for the file name format, which is not being used as unicode, even though it is locally, on travis-ci and on Alfred tests, but not on the bot instance.