### PR TITLE
Pass digest_config instead

### DIFF
--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -128,9 +128,8 @@ def handle_zip(file_name, temp_dir):
     return docx_file_name, image_file_name
 
 
-def build_digest(file_name, temp_dir='tmp', config_section=None):
+def build_digest(file_name, temp_dir='tmp', digest_config=None):
     "build a digest object from a DOCX input file"
-    digest_config = parse_raw_config(raw_config(config_section))
     digest = None
     docx_file_name, image_file_name = handle_zip(file_name, temp_dir)
     content = parse_content(docx_file_name)

--- a/digestparser/medium_post.py
+++ b/digestparser/medium_post.py
@@ -136,12 +136,11 @@ def digest_medium_content_format(digest_config):
     return content_format
 
 
-def build_medium_content(file_name, config_section=None, jats_file_name=None):
+def build_medium_content(file_name, digest_config=None, jats_file_name=None):
     "build Medium content from a DOCX input file"
-    digest_config = parse_raw_config(raw_config(config_section))
 
     # build the digest object
-    digest = build_digest(file_name, 'tmp', config_section)
+    digest = build_digest(file_name, 'tmp', digest_config)
 
     # override the text with the jats file digest content
     if jats_file_name:
@@ -170,10 +169,8 @@ def build_medium_content(file_name, config_section=None, jats_file_name=None):
     return medium_content
 
 
-def post_content(medium_content, config_section=None):
+def post_content(medium_content, digest_config=None):
     "post the Medium content to Medium"
-    digest_config = parse_raw_config(raw_config(config_section))
-
     medium_client = Client(
         application_id=digest_config.get('medium_application_client_id'),
         application_secret=digest_config.get('medium_application_client_secret'))

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -4,6 +4,7 @@ import os
 import unittest
 from ddt import ddt, data
 from tests import read_fixture, test_data_path
+from digestparser.conf import raw_config, parse_raw_config
 from digestparser import build
 
 
@@ -42,9 +43,9 @@ class TestBuild(unittest.TestCase):
         expected_image_credit = u'Anonymous and Anonymous'
         expected_image_license = u'CC BY 4.0'
         # build now
+        digest_config = parse_raw_config(raw_config(test_data.get('config_section')))
         digest = build.build_digest(test_data_path(test_data.get('file_name')),
-                                    'tmp',
-                                    test_data.get('config_section'))
+                                    'tmp', digest_config)
         # assert assertions
         self.assertIsNotNone(digest)
         self.assertEqual(digest.author, expected_author)

--- a/tests/test_medium.py
+++ b/tests/test_medium.py
@@ -125,24 +125,22 @@ class TestMediumFigure(unittest.TestCase):
 
     def test_build_medium_content(self):
         "test building from a DOCX file and converting to Medium content"
-        config_section = 'elife'
         docx_file = 'DIGEST 99999.docx'
         expected_medium_content = read_fixture('medium_content_99999.py')
         # build the digest object
         medium_content = medium_post.build_medium_content(test_data_path(docx_file),
-                                                          config_section)
+                                                          self.digest_config)
         # test assertions
         self.assertEqual(medium_content, expected_medium_content)
 
     def test_build_medium_content_with_jats(self):
         "test building from a DOCX file and converting to Medium content"
-        config_section = 'elife'
         docx_file = 'DIGEST 99999.zip'
         jats_file = fixture_file('elife-99999-v0.xml')
         expected_medium_content = read_fixture('medium_content_jats_99999.py')
         # build the digest object
         medium_content = medium_post.build_medium_content(
-            test_data_path(docx_file), config_section, jats_file)
+            test_data_path(docx_file), self.digest_config, jats_file)
         # test assertions
         self.assertEqual(medium_content, expected_medium_content)
 
@@ -152,7 +150,7 @@ class TestMediumFigure(unittest.TestCase):
         fake_client.return_value = MockClient()
         medium_content = None
         # do the action
-        post = medium_post.post_content(medium_content)
+        post = medium_post.post_content(medium_content, self.digest_config)
         # test assertions
         self.assertEqual(post.get('publishStatus'), 'draft')
 


### PR DESCRIPTION
Pass the digest_config to methods instead of the config_section name for better flexibility.

An improvement over the previous PR, which turned out to be too complicated to run tests when overriding the ``.cfg`` file loaded.