### PR TITLE
Image credit robust examples

### DIFF
--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -1,3 +1,4 @@
+import re
 from digestparser.parse import parse_content
 from digestparser.objects import Digest, Image
 from digestparser.zip import unzip_zip
@@ -93,12 +94,23 @@ def extract_image_content(content):
     credit = None
     license_value = None
     # split the content into separate values
-    first_parts = content.split('Image credit:')
-    caption = first_parts[0].rstrip()
-    # continue to split up the final parts
-    second_parts = first_parts[1].split('(')
-    credit = second_parts[0].lstrip().rstrip()
-    license_value = second_parts[1].rstrip(' )')
+    first_parts = re.split(r'Image [cC]redit:', content)
+    second_parts = None
+    if first_parts and len(first_parts) > 1:
+        if first_parts[0]:
+            caption = first_parts[0].rstrip()
+        second_parts = first_parts[1].split('(')
+    else:
+        # Image credit not present, then no caption, use the content as the second part
+        second_parts = content.split('(')
+    # continue to split up the credit and license
+    if second_parts:
+        if len(second_parts) == 1:
+            if second_parts[0]:
+                credit = ''.join(second_parts[0]).lstrip().rstrip()
+        else:
+            credit = '('.join(second_parts[0:-1]).lstrip().rstrip()
+            license_value = second_parts[-1].rstrip(' )')
     return caption, credit, license_value
 
 

--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -2,7 +2,6 @@ import re
 from digestparser.parse import parse_content
 from digestparser.objects import Digest, Image
 from digestparser.zip import unzip_zip
-from digestparser.conf import raw_config, parse_raw_config
 
 
 SECTION_MAP = {

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -144,6 +144,13 @@ https://doi.org/10.7554/eLife.99999
             'expected_credit': 'Anonymous (Anon.)',
             'expected_license_value': 'CC0'
         },
+        {
+            'scenario': 'Trick for a caption only',
+            'content': 'Caption. Image credit:',
+            'expected_caption': 'Caption.',
+            'expected_credit': None,
+            'expected_license_value': None
+        },
         )
     def test_extract_image_content(self, test_data):
         caption, credit, license_value = build.extract_image_content(test_data.get('content'))

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -101,6 +101,71 @@ https://doi.org/10.7554/eLife.99999
         doi = build.build_doi(content, digest_config)
         self.assertEqual(doi, expected_doi)
 
+    @data(
+        {
+            'scenario': 'Basic simple example',
+            'content': 'Caption. Image credit: Anonymous (CC BY 4.0)',
+            'expected_caption': 'Caption.',
+            'expected_credit': 'Anonymous',
+            'expected_license_value': 'CC BY 4.0'
+        },
+        {
+            'scenario': 'Empty example',
+            'content': '',
+            'expected_caption': None,
+            'expected_credit': None,
+            'expected_license_value': None
+        },
+        {
+            'scenario': 'Image Credit (upper-case) no caption no license',
+            'content': 'Image Credit: Public domain',
+            'expected_caption': None,
+            'expected_credit': 'Public domain',
+            'expected_license_value': None
+        },
+        {
+            'scenario': 'No caption with image credit and license',
+            'content': 'Anonymous (CC0)',
+            'expected_caption': None,
+            'expected_credit': 'Anonymous',
+            'expected_license_value': 'CC0'
+        },
+        {
+            'scenario': 'A simple string',
+            'content': 'Anonymous',
+            'expected_caption': None,
+            'expected_credit': 'Anonymous',
+            'expected_license_value': None
+        },
+        {
+            'scenario': 'Extra parentheses',
+            'content': 'Caption (subtitle). Image credit: Anonymous (Anon.) (CC0)',
+            'expected_caption': 'Caption (subtitle).',
+            'expected_credit': 'Anonymous (Anon.)',
+            'expected_license_value': 'CC0'
+        },
+        )
+    def test_extract_image_content(self, test_data):
+        caption, credit, license_value = build.extract_image_content(test_data.get('content'))
+        self.assertEqual(
+            caption, test_data.get('expected_caption'),
+            'failed in scenario {scenario}, got caption {value}, expected {expected}'.format(
+                scenario=test_data.get('scenario'),
+                value=caption,
+                expected=test_data.get('expected_caption')))
+        self.assertEqual(
+            credit, test_data.get('expected_credit'),
+            'failed in scenario {scenario}, got credit {value}, expected {expected}'.format(
+                scenario=test_data.get('scenario'),
+                value=credit,
+                expected=test_data.get('expected_credit')))
+        self.assertEqual(
+            license_value, test_data.get('expected_license_value'),
+            'failed in scenario {scenario}, got license {value}, expected {expected}'.format(
+                scenario=test_data.get('scenario'),
+                value=license_value,
+                expected=test_data.get('expected_license_value')))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/elifesciences/digest-parser/issues/44

These are based on some exceptions we're seeing on real data supplied to the docx parser. The code changes will avoid the ``IndexError`` problems when content is omitted, and for a slight change in the token ``"Image credit:"`` can also be upper case 'C' ``"Image Credit:"``.