### PR TITLE
Handle generating JSON from a very blank Digest

### DIFF
--- a/digestparser/json_output.py
+++ b/digestparser/json_output.py
@@ -57,12 +57,13 @@ def image_size(info):
     # only return size if it is non-empty
     if size:
         return size
+    return None
 
 
 def image_json(digest, digest_config):
     "format image details into JSON format"
     # need an image file name to continue
-    if not digest.image.file:
+    if not digest.image or not digest.image.file:
         return None
     msid = str(msid_from_doi(digest.doi))
     image_file_name = os.path.split(digest.image.file)[-1]
@@ -140,8 +141,9 @@ def digest_json(digest, digest_config, related=None):
         json_content['subjects'] = digest.subjects
     # content
     content = []
-    for text in digest.text:
-        content.append(content_paragraph(text))
+    if digest.text:
+        for text in digest.text:
+            content.append(content_paragraph(text))
     # insert the image before the first paragraph
     if content_image:
         content.insert(0, content_image)

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 
 import unittest
+from collections import OrderedDict
 from mock import patch
 from ddt import ddt, data
 from digestparser import json_output
+from digestparser.objects import Digest
 from digestparser.conf import raw_config, parse_raw_config
 from tests import read_fixture, test_data_path, fixture_file
 
@@ -113,6 +115,21 @@ class TestJsonOutput(unittest.TestCase):
         fake_get.return_value = FakeResponse({'width': 100})
         expected_info = {}
         self.assertEqual(json_output.iiif_server_info('http://iiif-error'), expected_info)
+
+    def test_digest_json_empty(self):
+        "test json output for an empty digest where there is no text or image file"
+        digest = Digest()
+        # reset some lists to None for testing
+        digest.text = None
+        digest.keywords = None
+        digest.subjects = None
+        expected = OrderedDict([
+            ('id', 'None'),
+            ('title', None),
+            ('impactStatement', None),
+            ('content', [])
+            ])
+        self.assertEqual(json_output.digest_json(digest, None), expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Test generating JSON from an empty digest with list properties set to None as well.

Will fix the error reported in https://github.com/elifesciences/issues/issues/4326 when `digest.text` is None to not break.