### PR TITLE
Add positive IIIF logs

### DIFF
--- a/digestparser/json_output.py
+++ b/digestparser/json_output.py
@@ -18,8 +18,10 @@ def iiif_server_info(info_url):
     if not info_url:
         return info
     try:
+        LOGGER.info("Loading IIIF info: %s", info_url)
         response = requests.get(info_url)
         info = response.json()
+        LOGGER.info("IIIF info for %s: %s", info_url, info)
     except Exception as exception:
         # could be any error right now
         LOGGER.exception("Exception in iiif_server_info for GET %s. Details: %s",


### PR DESCRIPTION
We have no logs when IIIF information is correctly used, this fills that gap and introduces the first INFO logs. I don't usually find a great need for logs in libraries, if not for the cases where they make external HTTP requests.