### PR TITLE
Do not add published to the JSON output by default

### DIFF
--- a/digestparser/json_output.py
+++ b/digestparser/json_output.py
@@ -166,11 +166,6 @@ def build_json(file_name, temp_dir='tmp', digest_config=None, jats_file_name=Non
         soup = parse_jats_file(jats_file_name)
         digest.text = parse_jats_digest(soup)
 
-        # set the published date from the jats file
-        pub_date = parse_jats_pub_date(soup)
-        if pub_date:
-            digest.published = time.strftime("%Y-%m-%dT%H:%M:%SZ", pub_date)
-
         # add subjects from the jats file
         digest.subjects = parse_jats_subjects(soup)
 

--- a/tests/fixtures/json_content_99999.py
+++ b/tests/fixtures/json_content_99999.py
@@ -6,7 +6,6 @@ EXPECTED = OrderedDict([
     ('id', u'99999'),
     ('title', u'Fishing for errors in the\xa0tests'),
     ('impactStatement', u'Testing a document which mimics the format of a file we’ve used  before plus CO<sub>2</sub> and Ca<sup>2+</sup>.'),
-    ('published', '2018-08-01T00:00:00Z'),
     ('image', OrderedDict([
         ('thumbnail', OrderedDict([
             ('uri', 'https://iiif.elifesciences.org/digests/99999%2Fdigest-99999.jpg'),

--- a/tests/fixtures/json_content_docx_and_jats_99999.py
+++ b/tests/fixtures/json_content_docx_and_jats_99999.py
@@ -6,7 +6,6 @@ EXPECTED = OrderedDict([
     ('id', u'99999'),
     ('title', u'Fishing for errors in the\xa0tests'),
     ('impactStatement', u'Testing a document which mimics the format of a file we’ve used  before plus CO<sub>2</sub> and Ca<sup>2+</sup>.'),
-    ('published', '2018-08-01T00:00:00Z'),
     ('subjects', [
         OrderedDict([
             ('id', 'biochemistry-chemical-biology'),


### PR DESCRIPTION
Do not add the published date to the JSON taken from the JATS XML by default.

Assuming the pub date in the JATS XML file is the one to be used in the digest JSON output is not a good assumption, and it is probably better to leave it out entirely. A value for `published` can be added later after the basic JSON is generated.