### PR TITLE
Build jats to accept and pass parameters

### DIFF
--- a/digestparser/jats.py
+++ b/digestparser/jats.py
@@ -101,8 +101,8 @@ def parse_jats_subjects(soup):
     return subjects
 
 
-def build_jats(file_name):
+def build_jats(file_name, temp_dir='tmp', digest_config=None):
     "build a digest object from a DOCX input file"
-    digest = build_digest(file_name)
+    digest = build_digest(file_name, temp_dir, digest_config)
     jats_content = digest_jats(digest)
     return jats_content

--- a/tests/test_jats.py
+++ b/tests/test_jats.py
@@ -2,6 +2,7 @@
 
 import unittest
 from ddt import ddt, data
+from elifetools.utils import date_struct
 from tests import read_fixture, test_data_path, fixture_file
 from digestparser.objects import Digest
 from digestparser import jats
@@ -70,6 +71,12 @@ class TestJats(unittest.TestCase):
         content = jats.parse_jats_digest(soup)
         expected_content = read_fixture('elife_99999_v0_digest.py')
         self.assertEqual(content, expected_content)
+
+    def test_parse_jats_pub_date(self):
+        "extract pub date from a JATS file"
+        soup = jats.parse_jats_file(fixture_file('elife-99999-v0.xml'))
+        pub_date = jats.parse_jats_pub_date(soup)
+        self.assertEqual(pub_date, date_struct(2018, 8, 1))
 
 
 if __name__ == '__main__':

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -131,6 +131,19 @@ class TestJsonOutput(unittest.TestCase):
             ])
         self.assertEqual(json_output.digest_json(digest, None), expected)
 
+    def test_digest_json_published_value(self):
+        "test json output for a digest with a published value"
+        digest = Digest()
+        digest.published = '2018-10-29'
+        expected = OrderedDict([
+            ('id', 'None'),
+            ('title', None),
+            ('impactStatement', None),
+            ('published', '2018-10-29'),
+            ('content', [])
+            ])
+        self.assertEqual(json_output.digest_json(digest, None), expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In preparation for using JATS output from the digest library, allow the `temp_dir` and `digest_config` to be optionally passed to `build_jats()`, which ends up calling `build_digest()` that now accepts these parameters.

Added some test cases for test coverage since setting a Digest's pub date by default from the JATS pub date was recently disabled, to make sure these functions are still functioning correctly, just in case.