### PR TITLE
Change test_data_path and unicode conf

### DIFF
--- a/digestparser/conf.py
+++ b/digestparser/conf.py
@@ -1,7 +1,7 @@
 import configparser as configparser
 import json
 
-CONFIG_FILE = 'digest.cfg'
+CONFIG_FILE = u'digest.cfg'
 BOOLEAN_VALUES = []
 INT_VALUES = []
 LIST_VALUES = []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,6 +34,6 @@ def read_fixture(filename, folder_name=''):
         with open(full_filename, 'rb') as file_fp:
             return file_fp.read()
 
-def test_data_path(file_name):
+def data_path(file_name):
     "path for a file in the test_data directory"
     return os.path.join(BASE_DIR, 'tests', 'test_data', file_name)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -3,7 +3,7 @@
 import os
 import unittest
 from ddt import ddt, data
-from tests import read_fixture, test_data_path
+from tests import read_fixture, data_path
 from digestparser.conf import raw_config, parse_raw_config
 from digestparser import build
 
@@ -43,7 +43,7 @@ class TestBuild(unittest.TestCase):
                                   u'\xa0Image credit:\xa0Anonymous and Anonymous\xa0(CC BY\xa04.0)')
         # build now
         digest_config = parse_raw_config(raw_config(test_data.get('config_section')))
-        digest = build.build_digest(test_data_path(test_data.get('file_name')),
+        digest = build.build_digest(data_path(test_data.get('file_name')),
                                     'tmp', digest_config)
         # assert assertions
         self.assertIsNotNone(digest)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -17,11 +17,11 @@ class TestConf(unittest.TestCase):
 
     def setUp(self):
         # some values for testing
-        self.boolean_value = 'True'
+        self.boolean_value = u'True'
         self.boolean_expected = True
-        self.int_value = '42'
+        self.int_value = u'42'
         self.int_expected = 42
-        self.list_value = '[1,1,2,3,5]'
+        self.list_value = u'[1,1,2,3,5]'
         self.list_expected = [1, 1, 2, 3, 5]
 
     def test_load_config(self):
@@ -38,7 +38,7 @@ class TestConf(unittest.TestCase):
     def test_boolean_config(self):
         "test parsing a boolean value"
         value = self.boolean_value
-        value_name = 'test'
+        value_name = u'test'
         expected = self.boolean_expected
         raw_config = build_raw_config_for_testing(value_name, value)
         self.assertEqual(conf.boolean_config(raw_config, value_name), expected)
@@ -46,7 +46,7 @@ class TestConf(unittest.TestCase):
     def test_int_config(self):
         "test parsing an int value"
         value = self.int_value
-        value_name = 'test'
+        value_name = u'test'
         expected = self.int_expected
         raw_config = build_raw_config_for_testing(value_name, value)
         self.assertEqual(conf.int_config(raw_config, value_name), expected)
@@ -54,7 +54,7 @@ class TestConf(unittest.TestCase):
     def test_list_config(self):
         "test parsing a list value"
         value = self.list_value
-        value_name = 'test'
+        value_name = u'test'
         expected = self.list_expected
         raw_config = build_raw_config_for_testing(value_name, value)
         self.assertEqual(conf.list_config(raw_config, value_name), expected)
@@ -62,14 +62,14 @@ class TestConf(unittest.TestCase):
     def test_parse_raw_config(self):
         "test parsing a raw config of all the different value types"
         # override the library values
-        conf.BOOLEAN_VALUES = ['test_boolean']
-        conf.INT_VALUES = ['test_int']
-        conf.LIST_VALUES = ['test_list']
+        conf.BOOLEAN_VALUES = [u'test_boolean']
+        conf.INT_VALUES = [u'test_int']
+        conf.LIST_VALUES = [u'test_list']
         # build a config object
         config = configparser.ConfigParser(interpolation=None)
-        config['DEFAULT']['test_boolean'] = self.boolean_value
-        config['DEFAULT']['test_int'] = self.int_value
-        config['DEFAULT']['test_list'] = self.list_value
+        config['DEFAULT'][u'test_boolean'] = self.boolean_value
+        config['DEFAULT'][u'test_int'] = self.int_value
+        config['DEFAULT'][u'test_list'] = self.list_value
         # parse the raw config for coverage
         config_dict = conf.parse_raw_config(config['DEFAULT'])
         # assert some things

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -2,7 +2,7 @@
 
 import unittest
 from digestparser import build, html
-from tests import read_fixture, test_data_path
+from tests import read_fixture, data_path
 
 
 class TestHtml(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestHtml(unittest.TestCase):
         expected_text_2 = read_fixture('html_content_99999_text_2.txt').decode('utf-8')
         expected_text_3 = read_fixture('html_content_99999_text_3.txt').decode('utf-8')
         # build the digest object
-        digest = build.build_digest(test_data_path(docx_file))
+        digest = build.build_digest(data_path(docx_file))
         # test assertions
         self.assertEqual(html.string_to_html(digest.title), expected_title)
         self.assertEqual(html.string_to_html(digest.summary), expected_summary)

--- a/tests/test_jats.py
+++ b/tests/test_jats.py
@@ -3,7 +3,7 @@
 import unittest
 from ddt import ddt, data
 from elifetools.utils import date_struct
-from tests import read_fixture, test_data_path, fixture_file
+from tests import read_fixture, data_path, fixture_file
 from digestparser.objects import Digest
 from digestparser import jats
 
@@ -47,7 +47,7 @@ class TestJats(unittest.TestCase):
         "check building JATS XML content from a DOCX file"
         docx_file = 'DIGEST 99999.docx'
         expected_content = read_fixture('jats_content_99999.txt').decode('utf-8')
-        jats_content = jats.build_jats(test_data_path(docx_file))
+        jats_content = jats.build_jats(data_path(docx_file))
         self.assertEqual(jats_content, expected_content)
 
     @data(

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -7,7 +7,7 @@ from ddt import ddt, data
 from digestparser import json_output
 from digestparser.objects import Digest
 from digestparser.conf import raw_config, parse_raw_config
-from tests import read_fixture, test_data_path, fixture_file
+from tests import read_fixture, data_path, fixture_file
 
 
 class FakeResponse(object):
@@ -83,7 +83,7 @@ class TestJsonOutput(unittest.TestCase):
     def test_build_json(self, test_data, fake_iiif_server_info):
         "check building a JSON from a DOCX file"
         fake_iiif_server_info.return_value = test_data.get('iiif_info')
-        file_name = test_data_path(test_data.get('file_name'))
+        file_name = data_path(test_data.get('file_name'))
         jats_file = fixture_file(test_data.get('jats_file'))
         expected_json = read_fixture(test_data.get('expected_json_file'))
         # config

--- a/tests/test_medium.py
+++ b/tests/test_medium.py
@@ -5,7 +5,7 @@ from mock import patch
 from digestparser.conf import raw_config, parse_raw_config
 from digestparser.objects import Image, Digest
 from digestparser import medium_post
-from tests import read_fixture, test_data_path, fixture_file
+from tests import read_fixture, data_path, fixture_file
 
 
 class MockClient(object):
@@ -117,7 +117,7 @@ class TestMediumFigure(unittest.TestCase):
         docx_file = 'DIGEST 99999.docx'
         expected_medium_content = read_fixture('medium_content_99999.py')
         # build the digest object
-        medium_content = medium_post.build_medium_content(test_data_path(docx_file),
+        medium_content = medium_post.build_medium_content(data_path(docx_file),
                                                           self.digest_config)
         # test assertions
         self.assertEqual(medium_content, expected_medium_content)
@@ -129,7 +129,7 @@ class TestMediumFigure(unittest.TestCase):
         expected_medium_content = read_fixture('medium_content_jats_99999.py')
         # build the digest object
         medium_content = medium_post.build_medium_content(
-            test_data_path(docx_file), self.digest_config, jats_file)
+            data_path(docx_file), self.digest_config, jats_file)
         # test assertions
         self.assertEqual(medium_content, expected_medium_content)
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -8,7 +8,7 @@ from digestparser.objects import Digest
 from digestparser.parse import parse_content
 from digestparser.build import build_digest
 from digestparser.conf import raw_config, parse_raw_config
-from tests import test_data_path, fixture_file
+from tests import data_path, fixture_file
 
 
 @ddt
@@ -28,12 +28,12 @@ class TestOutput(unittest.TestCase):
         "check building a DOCX from a DOCX file"
         file_name = test_data.get('file_name')
         output_dir = test_data.get('output_dir')
-        digest = build_digest(test_data_path(file_name))
+        digest = build_digest(data_path(file_name))
         output_file_name = output.docx_file_name(digest)
         expected_fixture = fixture_file(test_data.get('expected_docx_file'))
         # build now
         full_file_name = os.path.join(output_dir, output_file_name)
-        docx_file = output.build_docx(test_data_path(file_name), full_file_name)
+        docx_file = output.build_docx(data_path(file_name), full_file_name)
         # assert assertions
         self.assertEqual(docx_file, os.path.join(output_dir, output_file_name))
         # parse and compare the content of the built docx and the fixture docx

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,7 +1,7 @@
 import unittest
 from ddt import ddt, data
 from digestparser import parse
-from tests import read_fixture, test_data_path
+from tests import read_fixture, data_path
 
 
 @ddt
@@ -13,7 +13,7 @@ class TestParse(unittest.TestCase):
     def test_parse_content(self):
         "test parsing all the content"
         expected = read_fixture('digest_99999.txt').decode('utf-8')
-        content = parse.parse_content(test_data_path('DIGEST 99999.docx'))
+        content = parse.parse_content(data_path('DIGEST 99999.docx'))
         self.assertEqual(content, expected)
 
     def test_html_open_close_tag_failure(self):

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -2,7 +2,7 @@
 
 import unittest
 from ddt import ddt, data, unpack
-from tests import test_data_path
+from tests import data_path
 from digestparser.zip import profile_zip
 
 
@@ -19,7 +19,7 @@ class TestZip(unittest.TestCase):
     @unpack
     def test_profile_zip(self, zip_file, expected_docx, expected_image):
         "test parsing of zip file to find the docx and image file names"
-        docx, image = profile_zip(test_data_path(zip_file))
+        docx, image = profile_zip(data_path(zip_file))
         self.assertEqual(docx, expected_docx,
                          'file_name {file_name}, expected {expected}, got {output}'.format(
                              file_name=zip_file, expected=expected_docx, output=docx))


### PR DESCRIPTION
Planning to initialise a new code repo, I thought I would switch to using `pytest`, so I tried to run the tests on this library. 

After some amount of troubleshooting, I found it was picking up on the `test_data_path()` function thinking it was some sort of test fixture, which it is not. That function is renamed here.

`pytest` also displayed warnings about bytecode values being explicitly converted to unicode in the configparser usage, and I set those values to unicode strings to avoid the warnings.

Not a critical PR, but it means this library will be `pytest` compatible if merged.