### PR TITLE
Join run styles in a different order depending on the previous style.

### DIFF
--- a/digestparser/parse.py
+++ b/digestparser/parse.py
@@ -95,10 +95,12 @@ def run_open_close_style(run, prev_run, output, attribute):
 
 def join_run_tags(run, prev_run, output=''):
     "process all the possible tags in the run"
-    output = run_open_close_style(run, prev_run, output, 'italic')
-    output = run_open_close_style(run, prev_run, output, 'bold')
-    output = run_open_close_style(run, prev_run, output, 'subscript')
-    output = run_open_close_style(run, prev_run, output, 'superscript')
+    style_order = ['italic', 'bold', 'subscript', 'superscript']
+    if run_has_attr(prev_run, 'bold'):
+        # close bold tags first if previous run was bold
+        style_order = ['bold', 'italic', 'subscript', 'superscript']
+    for style in style_order:
+        output = run_open_close_style(run, prev_run, output, style)
     return output
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,5 +1,6 @@
 import unittest
 from ddt import ddt, data
+from docx import Document
 from digestparser import parse
 from tests import read_fixture, test_data_path
 
@@ -98,6 +99,24 @@ class TestParse(unittest.TestCase):
             test_data.get('output'),
             test_data.get('attribute')),
                          test_data.get('expected'))
+
+    def test_join_runs_bold_italic(self):
+        "test to join bold run before an italic run"
+        document = Document()
+        paragraph = document.add_paragraph('')
+        paragraph.add_run('bold ').bold = True
+        paragraph.add_run('italic.').italic = True
+        output = parse.join_runs(paragraph.runs)
+        self.assertEqual(output, '<b>bold</b> <i>italic.</i>')
+
+    def test_join_runs_italic_italic(self):
+        "test to join italic run before a bold run"
+        document = Document()
+        paragraph = document.add_paragraph('')
+        paragraph.add_run('italic ').italic = True
+        paragraph.add_run('bold.').bold = True
+        output = parse.join_runs(paragraph.runs)
+        self.assertEqual(output, '<i>italic</i> <b>bold.</b>')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reference to issue https://github.com/elifesciences/issues/issues/4581

When joining runs and including HTML style tags, the order of the styles processed matters. In the current logic the close tags are added first, so if the `italic` style is processed on a bold previous run first, then `bold` processed next, it can end up as `<b>Heading<i></b>Next line</i>`.

This is a quick fix that only addresses bold and italic, processing them in a different order depending on which style comes first, and satisfies the very basic parsing rules we have so far. There could be a better way, this is just a first quick fix.

Included are two tests that run on dynamically generated `Document` objects, which saves having to deal with many `.docx` files.