### PR TITLE
Specify temp_dir and image_file_name name when building medium content.

### DIFF
--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -110,10 +110,12 @@ def handle_zip(file_name, temp_dir):
     return docx_file_name, image_file_name
 
 
-def build_digest(file_name, temp_dir='tmp', digest_config=None):
+def build_digest(file_name, temp_dir='tmp', digest_config=None, image_file_name=None):
     "build a digest object from a DOCX input file"
     digest = None
-    docx_file_name, image_file_name = handle_zip(file_name, temp_dir)
+    docx_file_name, zip_image_file_name = handle_zip(file_name, temp_dir)
+    if not image_file_name:
+        image_file_name = zip_image_file_name
     content = parse_content(docx_file_name)
     if content:
         digest = Digest()

--- a/digestparser/medium_post.py
+++ b/digestparser/medium_post.py
@@ -124,11 +124,12 @@ def digest_medium_content_format(digest_config):
     return content_format
 
 
-def build_medium_content(file_name, digest_config=None, jats_file_name=None):
+def build_medium_content(file_name, temp_dir='tmp', digest_config=None, 
+                         jats_file_name=None, image_file_name=None):
     "build Medium content from a DOCX input file"
 
     # build the digest object
-    digest = build_digest(file_name, 'tmp', digest_config)
+    digest = build_digest(file_name, temp_dir, digest_config, image_file_name)
 
     # override the text with the jats file digest content
     if jats_file_name:

--- a/tests/test_medium.py
+++ b/tests/test_medium.py
@@ -117,19 +117,31 @@ class TestMediumFigure(unittest.TestCase):
         docx_file = 'DIGEST 99999.docx'
         expected_medium_content = read_fixture('medium_content_99999.py')
         # build the digest object
-        medium_content = medium_post.build_medium_content(data_path(docx_file),
-                                                          self.digest_config)
+        medium_content = medium_post.build_medium_content(
+            data_path(docx_file), 'tmp', self.digest_config)
         # test assertions
         self.assertEqual(medium_content, expected_medium_content)
 
     def test_build_medium_content_with_jats(self):
-        "test building from a DOCX file and converting to Medium content"
+        "test building from a zip file and converting to Medium content"
         docx_file = 'DIGEST 99999.zip'
         jats_file = fixture_file('elife-99999-v0.xml')
         expected_medium_content = read_fixture('medium_content_jats_99999.py')
         # build the digest object
         medium_content = medium_post.build_medium_content(
-            data_path(docx_file), self.digest_config, jats_file)
+            data_path(docx_file), 'tmp', self.digest_config, jats_file)
+        # test assertions
+        self.assertEqual(medium_content, expected_medium_content)
+
+    def test_build_medium_content_with_jats_and_image(self):
+        "test building from a DOCX file and converting to Medium content"
+        docx_file = 'DIGEST 99999.docx'
+        jats_file = fixture_file('elife-99999-v0.xml')
+        image_file_name = 'IMAGE 99999.jpeg'
+        expected_medium_content = read_fixture('medium_content_jats_99999.py')
+        # build the digest object
+        medium_content = medium_post.build_medium_content(
+            data_path(docx_file), 'tmp', self.digest_config, jats_file, image_file_name)
         # test assertions
         self.assertEqual(medium_content, expected_medium_content)
 


### PR DESCRIPTION
Breaking change on `build_medium_content()` to insert the `temp_dir` into the parameter list. We are not using this function yet, and I presume it will be ok.

In continuing the bot activity integration for Medium posts, this solves issues there
- be able to pass the temporary directory to the function where it can unzip or save files, as required
- optionally specify the `image_file_name` for use in the Medium content, since the `.docx` and image file are separate in the bucket folder, instead of all in the original digest zip file