### PR TITLE
Author extra bold tag

### DIFF
--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -49,7 +49,7 @@ def build_list(section_name, content):
 
 
 def build_author(content):
-    return build_singleton('author', content)
+    return build_singleton('author', content).rstrip()
 
 
 def build_title(content):

--- a/digestparser/parse.py
+++ b/digestparser/parse.py
@@ -108,9 +108,13 @@ def join_runs(runs):
     output = ''
     prev_run = None
     for run in runs:
-        output = join_run_tags(run, prev_run, output)
-        output += run.text
-        prev_run = run
+        if run.text.strip():
+            output = join_run_tags(run, prev_run, output)
+            output += run.text
+            prev_run = run
+        else:
+            # if the text is only whitespace then do not enclose it in tags
+            output += run.text
     # finish up by running one last time with prev_run
     output = join_run_tags('', prev_run, output)
     return output

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -98,6 +98,12 @@ https://doi.org/10.7554/eLife.99999
         doi = build.build_doi(content, digest_config)
         self.assertEqual(doi, expected_doi)
 
+    def test_build_author_whitespace(self):
+        """test parsing an author name with trailing whitespace"""
+        author_name = 'Author Name'
+        content = '<b>AUTHOR</b>\n%s ' % author_name
+        self.assertEqual(build.build_author(content), author_name)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -118,6 +118,16 @@ class TestParse(unittest.TestCase):
         output = parse.join_runs(paragraph.runs)
         self.assertEqual(output, '<i>italic</i> <b>bold.</b>')
 
+    def test_join_blank_bold_tag(self):
+        """test joining runs with last run is a bold space"""
+        document = Document()
+        paragraph = document.add_paragraph('')
+        paragraph.add_run('Author Name')
+        paragraph.add_run(' ').bold = True
+        output = parse.join_runs(paragraph.runs)
+        # space will be retained but not the bold tag
+        self.assertEqual(output, 'Author Name ')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Reviewed the docx file that produces an extra empty bold tag in the author name in email subject lines, and this is a fix.

The docx is simulated in tests for the situation where there are two runs, the second one is a bold space space character. The solution when parsing it so not bother adding style tags to any whitespace.

Then, when building digest object values, strip any trailing whitespace from an author name. This saves having to clean the value further down the line, and the whitespace can be considered useless at that point.