### PR TITLE
More logging

### DIFF
--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -2,6 +2,7 @@ import re
 from digestparser.parse import parse_content
 from digestparser.objects import Digest, Image
 from digestparser.zip import unzip_zip
+from digestparser import LOGGER
 
 
 SECTION_MAP = {
@@ -114,6 +115,10 @@ def build_digest(file_name, temp_dir='tmp', digest_config=None, image_file_name=
     "build a digest object from a DOCX input file"
     digest = None
     docx_file_name, zip_image_file_name = handle_zip(file_name, temp_dir)
+    LOGGER.info(
+        "build_digest file '%s' has docx_file_name: '%s'", file_name, docx_file_name)
+    LOGGER.info(
+        "build_digest file '%s' has zip_image_file_name: '%s'", file_name, zip_image_file_name)
     if not image_file_name:
         image_file_name = zip_image_file_name
     content = parse_content(docx_file_name)

--- a/digestparser/zip.py
+++ b/digestparser/zip.py
@@ -3,6 +3,7 @@
 import zipfile
 import os
 from digestparser.utils import sanitise
+from digestparser import LOGGER
 
 
 def profile_zip(file_name):
@@ -32,11 +33,22 @@ def unzip_file(open_zipfile, zip_file_info, output_path):
 
 def zip_output_name(file_name, temp_dir):
     "a safe output path to unzip a file to"
+    LOGGER.info(
+        "zip_output_name file_name before decoding is '%s'", file_name)
     try:
         file_name = file_name.encode('cp437').decode('utf8')
     except UnicodeDecodeError:
         file_name = file_name
-    return os.path.join(temp_dir, sanitise(file_name))
+    LOGGER.info(
+        "zip_output_name file_name after decoding is '%s'", file_name)
+    safe_file_name = sanitise(file_name)
+    LOGGER.info(
+        "zip_output_name file_name '%s' to safe_file_name '%s'", file_name, safe_file_name)
+    zip_path = os.path.join(temp_dir, safe_file_name)
+    LOGGER.info(
+        "zip_output_name zip_path '%s' from temp_dir '%s', safe_file_name '%s'",
+        zip_path, temp_dir, safe_file_name)
+    return zip_path
 
 
 def unzip_zip(file_name, temp_dir):


### PR DESCRIPTION
Regarding internal issue https://github.com/elifesciences/issues/issues/4664, where some unicode file names are causing `UnicodeDecodeError` exception when run by the activity in `elife-bot`. Still trying to track down why this is, and here adding more logging to places where the file name is modified.