### PR TITLE
Encode the temp_dir path int eh zip_output_name, seems to help.

### DIFF
--- a/digestparser/zip.py
+++ b/digestparser/zip.py
@@ -44,7 +44,10 @@ def zip_output_name(file_name, temp_dir):
     safe_file_name = sanitise(file_name)
     LOGGER.info(
         "zip_output_name file_name '%s' to safe_file_name '%s'", file_name, safe_file_name)
-    zip_path = os.path.join(temp_dir, safe_file_name)
+    try:
+        zip_path = os.path.join(temp_dir.encode('utf8'), safe_file_name)
+    except (UnicodeDecodeError, TypeError):
+        zip_path = os.path.join(temp_dir, safe_file_name)
     LOGGER.info(
         "zip_output_name zip_path '%s' from temp_dir '%s', safe_file_name '%s'",
         zip_path, temp_dir, safe_file_name)


### PR DESCRIPTION
Continuing to troubleshoot the issue when unzipping unicode file names, in internal issue https://github.com/elifesciences/issues/issues/4664, encoding the value like this helped when testing last week. 

I haven't been able to craft a good workaround from the bot side of things, and this, if the test are passing, shouldn't hurt, and will hopefully fix one part of the issue.