### PR TITLE
Strip whitespace when looking for sections and from each content line

### DIFF
--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -1,4 +1,3 @@
-import re
 from digestparser.parse import parse_content
 from digestparser.objects import Digest, Image
 from digestparser.zip import unzip_zip

--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -23,14 +23,15 @@ def extract_section_content(section_name, content):
     target_section_heading = SECTION_MAP.get(section_name)
     extract_line = False
     for line in content.split("\n"):
-        if line == target_section_heading:
+        stripped_line = line.lstrip().rstrip()
+        if stripped_line == target_section_heading:
             # content will start on the next line
             extract_line = True
             continue
         if extract_line:
             # read lines until a new section heading is encountered
-            if line not in SECTION_MAP.values():
-                section_content.append(line)
+            if stripped_line not in SECTION_MAP.values():
+                section_content.append(stripped_line)
             else:
                 break
     return section_content

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -74,6 +74,16 @@ class TestBuild(unittest.TestCase):
         "test parsing image content from blank content for coverage"
         self.assertIsNone(build.build_image(''))
 
+    def test_build_image_whitespace(self):
+        """test parsing an image credit with whitespace"""
+        image_credit = 'Anon (CC BY 4.0)\n\n\n'
+        expected_image_credit = image_credit.rstrip()
+        image_file_name = 'digest-41540.jpg'
+        content = ' <b>IMAGE CREDIT</b> \n%s' % image_credit
+        image_object = build.build_image(content, image_file_name)
+        self.assertEqual(image_object.caption, expected_image_credit)
+        self.assertEqual(image_object.file, image_file_name)
+
     def test_build_doi_manuscript_number(self):
         "test parsing a doi with manuscript number, prefers manuscript number"
         content = '''


### PR DESCRIPTION
A `.docx` digest example in issue https://github.com/elifesciences/issues/issues/4785, has a space character after the image credit content which confuses the parser: `<b>IMAGE CREDIT</b> \n ...`

When searching for sections in the docx content, strip leading and following whitespace. Also, strip any right or left whitespace from content, because it will be a cleaner result when building the object properties. Any additional whitespace in these places holds no significance further along, at this time.

I will merge if tests are passing to deploy this bug fix ASAP.