### PR TITLE
No blank p tags in JATS output

### DIFF
--- a/digestparser/jats.py
+++ b/digestparser/jats.py
@@ -53,7 +53,7 @@ def digest_jats(digest):
     "convert a digest object to JATS XML output"
     jats_content = u''
     # convert text into paragraphs converting inline HTML tags
-    for text in digest.text:
+    for text in [text for text in digest.text if text]:
         jats_content += '<p>' + html_to_xml(text) + '</p>'
     return jats_content
 

--- a/digestparser/jats.py
+++ b/digestparser/jats.py
@@ -53,7 +53,7 @@ def digest_jats(digest):
     "convert a digest object to JATS XML output"
     jats_content = u''
     # convert text into paragraphs converting inline HTML tags
-    for text in [text for text in digest.text if text]:
+    for text in [text.strip() for text in digest.text if text and text.strip()]:
         jats_content += '<p>' + html_to_xml(text) + '</p>'
     return jats_content
 

--- a/tests/test_jats.py
+++ b/tests/test_jats.py
@@ -37,6 +37,7 @@ class TestJats(unittest.TestCase):
         digest.text = [
             "First <b>paragraph</b>.",
             "Second <i>paragraph</i>.",
+            ""
         ]
         expected_content = ("<p>First <bold>paragraph</bold>.</p><p>Second " +
                             "<italic>paragraph</italic>.</p>")

--- a/tests/test_jats.py
+++ b/tests/test_jats.py
@@ -37,7 +37,9 @@ class TestJats(unittest.TestCase):
         digest.text = [
             "First <b>paragraph</b>.",
             "Second <i>paragraph</i>.",
-            ""
+            "",
+            " ",
+            None
         ]
         expected_content = ("<p>First <bold>paragraph</bold>.</p><p>Second " +
                             "<italic>paragraph</italic>.</p>")


### PR DESCRIPTION
We recently started to send emails when each digest JATS is deposited to an endpoint. The JATS content is included in the email body, so it is more visible now for each document we process. Today, I noticed a digest with JATS that included a blank tag `<p></p>`.

The code here does not add blank or unsuitable text to the JATS output.

This doesn't fix it if there is a some HTML with no content, for example, `<i></i>` or `<b></b>`, but I haven't seen those yet. They would appear in JATS output as `<p><italic></italic></p>` or `<p><bold></bold><p>`, respectively.