### PR TITLE
Remove LINE SEPARATOR characters.

### DIFF
--- a/digestparser/__init__.py
+++ b/digestparser/__init__.py
@@ -8,6 +8,3 @@ FORMATTER = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 HDLR.setFormatter(FORMATTER)
 LOGGER.addHandler(HDLR)
 LOGGER.setLevel(logging.INFO)
-
-# character constants
-LINE_SEPARATOR = u'\u2028'

--- a/digestparser/__init__.py
+++ b/digestparser/__init__.py
@@ -8,3 +8,6 @@ FORMATTER = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 HDLR.setFormatter(FORMATTER)
 LOGGER.addHandler(HDLR)
 LOGGER.setLevel(logging.INFO)
+
+# character constants
+LINE_SEPARATOR = u'\u2028'

--- a/digestparser/parse.py
+++ b/digestparser/parse.py
@@ -1,6 +1,9 @@
 import sys
 from docx import Document
-from digestparser import LINE_SEPARATOR
+
+
+# character constants
+LINE_SEPARATOR = u'\u2028'
 
 
 def parse_content(file_name):

--- a/digestparser/parse.py
+++ b/digestparser/parse.py
@@ -1,5 +1,6 @@
 import sys
 from docx import Document
+from digestparser import LINE_SEPARATOR
 
 
 def parse_content(file_name):
@@ -110,7 +111,7 @@ def join_run_tags(run, prev_run, output=''):
 def remove_odd_characters(string):
     """replace invisible whitespace characters"""
     # LINE SEPARATOR
-    return string.replace('\u2028', '')
+    return string.replace(LINE_SEPARATOR, '')
 
 
 def join_runs(runs):

--- a/digestparser/parse.py
+++ b/digestparser/parse.py
@@ -4,10 +4,13 @@ from docx import Document
 
 def parse_content(file_name):
     "return all the content for testing"
-    content = ''
     document = Document(file_name)
-    # print(document.core_properties.author)
-    # print(document.paragraphs)
+    return parse_paragraphs(document)
+
+
+def parse_paragraphs(document):
+    """join the parsed paragraphs from the document"""
+    content = ''
     for para in document.paragraphs:
         content += join_runs(para.runs) + "\n"
     return content
@@ -104,17 +107,24 @@ def join_run_tags(run, prev_run, output=''):
     return output
 
 
+def remove_odd_characters(string):
+    """replace invisible whitespace characters"""
+    # LINE SEPARATOR
+    return string.replace('\u2028', '')
+
+
 def join_runs(runs):
     output = ''
     prev_run = None
     for run in runs:
-        if run.text.strip():
+        cleaned_text = remove_odd_characters(run.text)
+        if cleaned_text.strip():
             output = join_run_tags(run, prev_run, output)
-            output += run.text
+            output += cleaned_text
             prev_run = run
         else:
             # if the text is only whitespace then do not enclose it in tags
-            output += run.text
+            output += cleaned_text
     # finish up by running one last time with prev_run
     output = join_run_tags('', prev_run, output)
     return output

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,7 +1,8 @@
 import unittest
 from ddt import ddt, data
 from docx import Document
-from digestparser import parse, LINE_SEPARATOR
+from digestparser import parse
+from digestparser.parse import LINE_SEPARATOR
 from tests import read_fixture, data_path
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,7 +1,7 @@
 import unittest
 from ddt import ddt, data
 from docx import Document
-from digestparser import parse
+from digestparser import parse, LINE_SEPARATOR
 from tests import read_fixture, data_path
 
 
@@ -141,7 +141,7 @@ class TestParse(unittest.TestCase):
         paragraph2.add_run('TITLE').bold = True
         paragraph2.add_run('\n').bold = True
         # \u2028 will be stripped out
-        paragraph2.add_run('\u2028').bold = True
+        paragraph2.add_run(LINE_SEPARATOR).bold = True
         paragraph2.add_run('\u201C')
         paragraph2.add_run('A title')
         paragraph2.add_run('\u201D')

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -128,6 +128,28 @@ class TestParse(unittest.TestCase):
         # space will be retained but not the bold tag
         self.assertEqual(output, 'Author Name ')
 
+    def test_odd_whitespace(self):
+        """test joining runs with strange whitespace based on a real example"""
+        document = Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run('AUTHOR').bold = True
+        paragraph.add_run('\n')
+        paragraph.add_run('Author Name')
+        paragraph2 = document.add_paragraph()
+        paragraph2.add_run('DIGEST').bold = True
+        paragraph2.add_run(' ').bold = True
+        paragraph2.add_run('TITLE').bold = True
+        paragraph2.add_run('\n').bold = True
+        # \u2028 will be stripped out
+        paragraph2.add_run('\u2028').bold = True
+        paragraph2.add_run('\u201C')
+        paragraph2.add_run('A title')
+        paragraph2.add_run('\u201D')
+        output = parse.parse_paragraphs(document)
+        # space will be retained but not the bold tag
+        self.assertEqual(
+            output, '<b>AUTHOR</b>\nAuthor Name\n<b>DIGEST TITLE</b>\n\u201CA title\u201D\n')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Regarding issue https://github.com/elifesciences/issues/issues/4935 where a real `.docx` file which contained some LINE SEPARATOR characters (invisible in most software) caused an error in detecting the section titles.

I tried for a while to create a programmatic test case based on this `.docx` file. After finally figuring out in the logic why the test case was not passing, it looks to me the best idea is to strip out these characters from the final output. Here, they are stripped out before assembling runs.

If we didn't strip it out we'd get something like `<b>DIGEST TITLE</b><b>\u2028</b>...` and I don't think the bold LINE SEPARATOR character in the digest title would add any value.

I also refactoring the opening of a file to instantiate a `Document` from getting its paragraph runs, so it is easier to test from a file input or a `Document` class created using code in the test case.