### PR TITLE
If author is None do not rstrip() it.

### DIFF
--- a/digestparser/build.py
+++ b/digestparser/build.py
@@ -50,7 +50,8 @@ def build_list(section_name, content):
 
 
 def build_author(content):
-    return build_singleton('author', content).rstrip()
+    author = build_singleton('author', content)
+    return author.rstrip() if author else None
 
 
 def build_title(content):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -114,6 +114,11 @@ https://doi.org/10.7554/eLife.99999
         content = '<b>AUTHOR</b>\n%s ' % author_name
         self.assertEqual(build.build_author(content), author_name)
 
+    def test_build_author_none(self):
+        """test for when author is none"""
+        content = '<b>AUTHOR INCORRECT HEADING NAME</b>\nAuthor Name'
+        self.assertIsNone(build.build_author(content))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
An exception raised on input today in the running `elife-bot`, with log output like this:

```
  File "/opt/elife-bot/venv/local/lib/python2.7/site-packages/digestparser/build.py", line 127, in build_digest
    digest.author = build_author(content)
  File "/opt/elife-bot/venv/local/lib/python2.7/site-packages/digestparser/build.py", line 53, in build_author
    return build_singleton('author', content).rstrip()
AttributeError: 'NoneType' object has no attribute 'rstrip'
```

When I reviewed the `.docx` file for this digest, the `AUTHOR` heading name looked to have some extra whitespace in it, didn't match the pattern for the author heading, and so the content returned ends up as `None`. `rstrip()` will not work on `None` without some extra logic.

I added a test here similar to the real data, and accounted for when getting an author is `None`, do not try to strip it.

Considering the small change and test coverage, I will probably merge this without additional code review.