### PR TITLE
Remove py27 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "2.7"
+  - "3.5"
 # command to install dependencies
 install: ./travis-install.sh
 script: ./travis-test.sh

--- a/digestparser/medium_post.py
+++ b/digestparser/medium_post.py
@@ -1,6 +1,7 @@
 "compose a Medium post from digest content"
 
 import os
+import urllib
 from collections import OrderedDict
 from medium import Client
 from digestparser.build import build_digest
@@ -42,7 +43,7 @@ def image_formatter(digest_config, format_name, content=None):
             image_url=utils.formatter_string(content, 'image_url'),
             figcaption=utils.formatter_string(content, 'figcaption'),
             caption=utils.formatter_string(content, 'caption'),
-            file_name=utils.url_quote(utils.formatter_string(content, 'file_name')),
+            file_name=urllib.parse.quote(utils.formatter_string(content, 'file_name')),
             msid=utils.formatter_string(content, 'msid'),
             )
     return string

--- a/digestparser/output.py
+++ b/digestparser/output.py
@@ -3,7 +3,6 @@
 import os
 from bs4 import BeautifulSoup
 from docx import Document
-from elifetools.utils import unicode_value
 from digestparser.build import build_digest
 import digestparser.utils as utils
 
@@ -52,7 +51,7 @@ def docx_file_name(digest, digest_config=None):
     default_file_name_pattern = u'{author}_{msid:0>5}.docx'
     file_name_pattern = default_file_name_pattern
     if digest_config and 'output_file_name_pattern' in digest_config:
-        file_name_pattern = unicode_value(digest_config.get('output_file_name_pattern'))
+        file_name_pattern = str(digest_config.get('output_file_name_pattern'))
     # collect the values from the digest if present
     file_name = file_name_pattern.format(
         author=utils.unicode_decode(digest.author),

--- a/digestparser/output.py
+++ b/digestparser/output.py
@@ -54,7 +54,7 @@ def docx_file_name(digest, digest_config=None):
         file_name_pattern = str(digest_config.get('output_file_name_pattern'))
     # collect the values from the digest if present
     file_name = file_name_pattern.format(
-        author=utils.unicode_decode(digest.author),
+        author=digest.author,
         msid=str(utils.msid_from_doi(digest.doi))
     )
     return utils.sanitise_file_name(file_name)

--- a/digestparser/utils.py
+++ b/digestparser/utils.py
@@ -6,15 +6,6 @@ import urllib
 from slugify import slugify
 
 
-def unicode_decode(string):
-    "try to decode from utf8"
-    try:
-        string = string.decode('utf8')
-    except (UnicodeEncodeError, AttributeError):
-        pass
-    return string
-
-
 def sanitise(file_name):
     "replace unwanted characters in file name if present"
     if not file_name:
@@ -62,11 +53,3 @@ def msid_from_doi(doi):
     except (AttributeError, ValueError, IndexError):
         msid = None
     return msid
-
-
-def url_quote(string):
-    "escape for url quoting with python 2 or 3 method"
-    if hasattr(urllib, 'parse'):
-        # python 3
-        return urllib.parse.quote(string)
-    return urllib.quote(string)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests==2.20.0
 python-docx==0.8.6
 coverage==4.4.2
 ddt==1.1.0
-git+https://github.com/elifesciences/elife-tools.git@6c4f822ab8d1bed99c20da057a7907a6ad9a78ce#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@1ca1de40c9747a2ba25559ec5c5f52f00c1fd85e#egg=elifetools
 configparser==3.5.0
 git+https://github.com/Medium/medium-sdk-python.git@bdf34becf6dd24e3b1fc1048c36416bcba9fe0d6#egg=medium
 mock==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         ]
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py35
+envlist = py35
 [testenv]
 deps = -rrequirements.txt
 commands = coverage run -m unittest discover tests


### PR DESCRIPTION
Fixes https://github.com/elifesciences/digest-parser/issues/67

There's one remaining spot that tries to call string `.decode()` that will most certainly fail in Python 3, but it is related to the weird unicode file name buggy thing and I don't want to change it just now.

@lsh-0 only if you feel like reviewing, I don't think you've reviewed this library before.