### PR TITLE
Downstream release configuration for elife-bot

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -12,6 +12,11 @@ elifePipeline {
         tag = elifePypiRelease()
         elifeGitTagRevision(tag)
     }
-    
+
+    stage 'Downstream', {
+        elifeMainlineOnly {
+            build job: '/dependencies/dependencies-elife-bot-update-dependency', parameters: [string(name: 'package', value: 'digestparser'), string(name: 'tag', value: tag)], wait: false
+        }
+    }
 }
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6980, to automate the release of new library versions to the `elife-bot` project.